### PR TITLE
bugfix not working on Ubuntu 24.04

### DIFF
--- a/pim.go
+++ b/pim.go
@@ -238,7 +238,7 @@ func main() {
 	flag.Parse()
 
 	if version {
-		fmt.Println("Version:", Version())
+		fmt.Println("Version:", version)
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
 The downloaded linux version was giving 12:33PM ERR config file issue error="While parsing config: toml: invalid character at start of key: \x7f"
 
 So then I tried to build locally and ran into a build problem that this seemed to fix